### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -22,6 +22,20 @@ class ProductsController < ApplicationController
     @product = Product.find(params[:id])
   end
 
+  def edit
+    @product = Product.find(params[:id])
+  end
+
+  def update
+    product = Product.find(params[:id])
+    product.update(product_params)
+    if product.save
+      redirect_to root_path
+    else
+      render :edit
+    end  
+  end
+
   private
   def product_params
     params.require(:product).permit(:image, :title, :text, :product_category_id, :product_status_id, :burden_id, :prefecture_id, :days_id, :price).merge(user_id: current_user.id)

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,7 @@
 class ProductsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit]
   before_action :move_to_index, except: [:index, :show]
+  before_action :set_product, only: [:edit, :show, :update]
 
   def index
     @products = Product.all.order("created_at DESC")
@@ -20,15 +21,14 @@ class ProductsController < ApplicationController
   end
 
   def show
-    @product = Product.find(params[:id])
+    
   end
 
   def edit
-    @product = Product.find(params[:id])
+    
   end
 
   def update
-    @product = Product.find(params[:id])
     @product.update(product_params)
     if @product.save
       redirect_to root_path
@@ -47,6 +47,10 @@ class ProductsController < ApplicationController
     unless current_user.id == @product.user.id
       redirect_to action: :index
     end
+  end
+
+  def set_product
+    @product = Product.find(params[:id])
   end
 
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,7 +1,7 @@
 class ProductsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit]
-  before_action :move_to_index, except: [:index, :show]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
   before_action :set_product, only: [:edit, :show, :update]
+  before_action :move_to_index, only: [:edit, :update]
 
   def index
     @products = Product.all.order("created_at DESC")
@@ -29,8 +29,7 @@ class ProductsController < ApplicationController
   end
 
   def update
-    @product.update(product_params)
-    if @product.save
+    if @product.update(product_params)
       redirect_to root_path
     else
       render :edit
@@ -43,7 +42,6 @@ class ProductsController < ApplicationController
   end
 
   def move_to_index
-    @product = Product.find(params[:id])
     unless current_user.id == @product.user.id
       redirect_to action: :index
     end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -27,9 +27,9 @@ class ProductsController < ApplicationController
   end
 
   def update
-    product = Product.find(params[:id])
-    product.update(product_params)
-    if product.save
+    @product = Product.find(params[:id])
+    @product.update(product_params)
+    if @product.save
       redirect_to root_path
     else
       render :edit

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,6 @@
 class ProductsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
+  before_action :authenticate_user!, only: [:new, :create, :edit]
+  before_action :move_to_index, except: [:index, :show]
 
   def index
     @products = Product.all.order("created_at DESC")
@@ -39,6 +40,13 @@ class ProductsController < ApplicationController
   private
   def product_params
     params.require(:product).permit(:image, :title, :text, :product_category_id, :product_status_id, :burden_id, :prefecture_id, :days_id, :price).merge(user_id: current_user.id)
+  end
+
+  def move_to_index
+    @product = Product.find(params[:id])
+    unless current_user.id == @product.user.id
+      redirect_to action: :index
+    end
   end
 
 end

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -7,10 +7,9 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
-
+    <%= form_with model: @product, local: true do |f| %>
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
+    <%= render 'shared/error_messages', model: f.object %>
     <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 出品画像 %>
@@ -23,7 +22,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /出品画像 %>
@@ -33,13 +32,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :title, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :text, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +51,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:product_category_id, ProductCategory.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:product_status_id, ProductStatus.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +72,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:burden_id, Burden.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:days_id, Days.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +100,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -11,7 +11,6 @@ app/assets/stylesheets/items/new.css %>
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%= render 'shared/error_messages', model: f.object %>
     <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-
     <%# 出品画像 %>
     <div class="img-upload">
       <div class="weight-bold-text">

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -8,9 +8,7 @@ app/assets/stylesheets/items/new.css %>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @product, local: true do |f| %>
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%= render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%# 出品画像 %>
     <div class="img-upload">
       <div class="weight-bold-text">

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -24,7 +24,7 @@
 
     <% if user_signed_in? %>
       <% if current_user.id == @product.user.id %>
-        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <%= link_to "商品の編集", edit_product_path(@product.id), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
       <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   # get 'products/index'
   root to: "products#index"
-  resources :products, only: [:index, :new, :create, :show]
+  resources :products, only: [:index, :new, :create, :show, :edit, :update]
 end


### PR DESCRIPTION
# What
商品情報編集機能の実装

# Why
商品情報編集機能の実装のため

ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/77794880e67b7639e1bde6e7374b427e

正しく情報を記入すると、商品の情報を編集できる動画
https://gyazo.com/3b3f94bb7b5f596e57eb61c00b2b97a4

入力に問題のある状態では商品の情報は編集できず、エラーメッセージが出力される動画
https://gyazo.com/b823b03dc5b30303ca04a581258aa315

何も編集せずに更新をしても画像無しの商品にならない動画
https://gyazo.com/c0ccc6dbc2378748679d2ec2aa1275a4

ログイン状態のユーザーであっても、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/b203481ee95a076ccbf11e635c49bf36

ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移する動画
https://gyazo.com/6ed3e58e644adb194d407d6ef3d3fd23

商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（画像に関しては、表示されない状態で良い）
https://gyazo.com/53c0fab97c523c0646400e9bfa8bda97

現段階で商品購入機能の実装が済んでいないので下記はできていません。
ログイン状態の出品者であっても、URLを直接入力して自身の売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（現段階で商品購入機能の実装が済んでいる場合）

確認お願いします。